### PR TITLE
Add priority tags on card

### DIFF
--- a/src/Contexts/notesActions-context.jsx
+++ b/src/Contexts/notesActions-context.jsx
@@ -15,6 +15,7 @@ const NotesProvider = ({ children }) => {
         flag : false, 
         _id : "",
         color : "",
+        priority : "",
         tags : []
     });
 

--- a/src/components/Archive-Card/ArchiveCard.jsx
+++ b/src/components/Archive-Card/ArchiveCard.jsx
@@ -20,7 +20,10 @@ const ArchiveCard = ({ archive }) => {
                 <div className="notes-content">
                     <div className="title-and-date-box">
                         <h3 className="card-title"> {archive.title} </h3>
-                        <p className="note-date"> {archive.date} </p>
+                        <div className="date-and-priority-box">
+                            <p className={`priority-tag ${archive.priority && archive.priority}`}>{archive.priority}</p>
+                            <p className="note-date"> {archive.date} </p>
+                        </div>
                     </div>
                     <div className="card-content" dangerouslySetInnerHTML={{ __html: archive.content}} /> 
                 </div>

--- a/src/components/Card/NotesCard.css
+++ b/src/components/Card/NotesCard.css
@@ -29,7 +29,7 @@
 }
 
 .card-title {
-    margin-bottom: .5rem;
+    margin-bottom: 1rem;
     margin-left: 1rem;
 
 }
@@ -170,4 +170,33 @@
     font-size: 1.1rem;
     text-align: center;
     cursor: pointer;
+}
+
+/* priority */ 
+ 
+.date-and-priority-box {
+    display: flex;
+    gap: 1rem;
+}
+
+.priority-tag  {
+    font-size: .85rem;
+    color: #fff;
+    padding: 2px 5px;
+    padding-bottom: 0;
+    padding-top: 5px;
+    border-bottom-left-radius: 6px;
+    border-bottom-right-radius: 6px;
+}
+
+.High {
+    background-color: #f34f4f;
+}
+
+.Medium {
+    background-color: #f3a64f;
+}
+
+.Low {
+    background-color: #45bce4;
 }

--- a/src/components/Card/NotesCard.jsx
+++ b/src/components/Card/NotesCard.jsx
@@ -5,7 +5,6 @@ import { MdOutlineColorLens } from 'react-icons/md';
 import { FiTrash2 } from 'react-icons/fi';
 import { MdOutlineModeEdit } from 'react-icons/md';
 import { MdInvertColorsOff } from 'react-icons/md';
-import axios from "axios";
 import { useAuth } from "../../Contexts/authentication-context";
 import { useNote } from "../../Contexts/notesActions-context";
 import { deleteNote } from "../../Utilities-Functions/deleteNote";
@@ -61,12 +60,20 @@ const NotesCard = ({ note }) => {
         setTagBox(pre => !pre);
     }
 
+    const priorityAdd = (e) => {
+        const addedPriority = {...note, priority:e.target.value};
+        editNote(addedPriority, authState, noteDispatch, setUserNote);
+    }
+
     return (
         <div className={`notes-card ${note.color}`}>
             <div className="notes-content" >
                 <div className="title-and-date-box">
                     <h3 className="card-title"> {note.title} </h3>
-                    <p className="note-date"> {note.date} </p>
+                    <div className="date-and-priority-box">
+                        <p className={`priority-tag ${note.priority && note.priority}`}>{note.priority}</p>
+                        <p className="note-date"> {note.date} </p>
+                    </div>
                 </div>
                 <div className="card-content" dangerouslySetInnerHTML={{ __html: note.content}} />
             </div>
@@ -186,6 +193,12 @@ const NotesCard = ({ note }) => {
                 <RiInboxArchiveLine onClick={() => archiveNotes(note, authState, noteDispatch, setUserNote)} className="card-tool cursor" />
                 <FiTrash2 onClick={() => deleteNote(note, authState, noteDispatch, setUserNote)} className="card-tool cursor "/>
                 <MdOutlineModeEdit onClick={() => changeInputs(note)} className="card-tool cursor "/>
+                <select onChange={(e) => priorityAdd(e)} id="Priority" value={note.priority} >
+                    <option value="">Priority</option>
+                    <option value="High">High</option>
+                    <option value="Medium">Medium</option>
+                    <option value="Low">Low</option>
+                </select>
             </div>
         </div>
     )

--- a/src/components/TagsCard/TagsCard.jsx
+++ b/src/components/TagsCard/TagsCard.jsx
@@ -8,7 +8,10 @@ const TagsCard = ({note}) => {
             <div className="notes-content" >
                 <div className="title-and-date-box">
                     <h3 className="card-title"> {note.title} </h3>
-                    <p className="note-date"> {note.date} </p>
+                    <div className="date-and-priority-box">
+                        <p className={`priority-tag ${note.priority && note.priority}`}>{note.priority}</p>
+                        <p className="note-date"> {note.date} </p>
+                    </div>
                 </div>
                 <div className="card-content" dangerouslySetInnerHTML={{ __html: note.content}} />
             </div>

--- a/src/components/Trash-Card/TrashCard.jsx
+++ b/src/components/Trash-Card/TrashCard.jsx
@@ -26,7 +26,10 @@ const TrashCard = ({note}) => {
             <div className="notes-content">
                 <div className="title-and-date-box">
                     <h3 className="card-title"> {note.title} </h3>
-                    <p className="note-date"> {note.date} </p>
+                    <div className="date-and-priority-box">
+                        <p className={`priority-tag ${note.priority && note.priority}`}>{note.priority}</p>
+                        <p className="note-date"> {note.date} </p>
+                    </div>
                 </div>
                 <div className="card-content" dangerouslySetInnerHTML={{ __html: note.content}} /> 
             </div>


### PR DESCRIPTION
Test Link: https://cheer-notes-hmcx6e4m4-jay-gadhiya.vercel.app/

Functionality adds: 
- Set priority by selecting options of priorities shown on the card.
- Reset priority by selecting the "Priority" option.
